### PR TITLE
fix: drop unused code and emit all delegate changes via SetDelegates

### DIFF
--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -29,7 +29,10 @@ contract MerkleDelegation is Ownable, Pausable {
         governanceToken = _governanceToken;
     }
 
-    function setDelegateTrie(address delegator, bytes32 trieRoot) external whenNotPaused {
+    function setDelegateTrie(address delegator, bytes32 trieRoot)
+        external
+        whenNotPaused
+    {
         require(delegator == msg.sender, "delegator must be msg.sender");
         require(trieRoot != bytes32(0), "trieRoot must be non-zero");
         delegation[delegator].trieRoot = trieRoot;
@@ -39,8 +42,17 @@ contract MerkleDelegation is Ownable, Pausable {
 
     function clearDelegateTrie(address delegator) external whenNotPaused {
         require(delegator == msg.sender, "delegator must be msg.sender");
-        delete delegation[delegator];
-        emit SetDelegates(delegator, bytes32(0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421), block.number);
+        delegation[delegator].trieRoot = bytes32(
+            0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+        );
+        delegation[delegator].blockNumber = block.number;
+        emit SetDelegates(
+            delegator,
+            bytes32(
+                0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+            ),
+            block.number
+        );
     }
 
     function pause() external onlyOwner whenNotPaused {
@@ -51,17 +63,38 @@ contract MerkleDelegation is Ownable, Pausable {
         _unpause();
     }
 
-    function getDelegateRoot(address delegator) external view returns (bytes32 trieRoot) {
+    function getDelegateRoot(address delegator)
+        external
+        view
+        returns (bytes32 trieRoot)
+    {
         require(delegator != address(0), "delegator must be non-zero");
-        return delegation[delegator].trieRoot;
+        if (delegation[delegator].trieRoot != bytes32(0)) {
+            return delegation[delegator].trieRoot;
+        } else {
+            return
+                bytes32(
+                    0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+                );
+        }
     }
 
-    function getDelegateBlockNumber(address delegator) external view returns (uint256 blockNumber) {
+    function getDelegateBlockNumber(address delegator)
+        external
+        view
+        returns (uint256 blockNumber)
+    {
         require(delegator != address(0), "delegator must be non-zero");
         return delegation[delegator].blockNumber;
     }
 
-    function transferOwnership(address newOwner) public virtual override onlyOwner whenNotPaused {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override
+        onlyOwner
+        whenNotPaused
+    {
         _transferOwnership(newOwner);
     }
 }

--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -67,15 +67,6 @@ contract MerkleDelegation is Ownable, Pausable {
         );
     }
 
-    function getDelegateBlockNumber(address delegator)
-        external
-        view
-        returns (uint256 blockNumber)
-    {
-        require(delegator != address(0), "delegator must be non-zero");
-        return delegation[delegator].blockNumber;
-    }
-
     function transferOwnership(address newOwner)
         public
         virtual

--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -17,6 +17,10 @@ contract MerkleDelegation is Ownable, Pausable {
     address public immutable governanceToken;
     mapping(address => DelegatorRecord) public delegation;
     mapping(address => address) public delegateToDelegator;
+    bytes32 public constant EMPTY_MERKLE_TRIE_ROOT =
+        bytes32(
+            0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+        );
 
     event SetDelegates(
         address indexed delegator,
@@ -40,12 +44,7 @@ contract MerkleDelegation is Ownable, Pausable {
 
     function clearDelegateTrie(address delegator) external whenNotPaused {
         require(delegator == msg.sender, "delegator must be msg.sender");
-        _setDelegateTrie(
-            delegator,
-            bytes32(
-                0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
-            )
-        );
+        _setDelegateTrie(delegator, EMPTY_MERKLE_TRIE_ROOT);
     }
 
     function pause() external onlyOwner whenNotPaused {
@@ -62,14 +61,7 @@ contract MerkleDelegation is Ownable, Pausable {
         returns (bytes32 trieRoot)
     {
         require(delegator != address(0), "delegator must be non-zero");
-        if (delegation[delegator].trieRoot != bytes32(0)) {
-            return delegation[delegator].trieRoot;
-        } else {
-            return
-                bytes32(
-                    0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
-                );
-        }
+        return delegation[delegator].trieRoot;
     }
 
     function getDelegateBlockNumber(address delegator)

--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -55,13 +55,21 @@ contract MerkleDelegation is Ownable, Pausable {
         _unpause();
     }
 
-    function getDelegateRoot(address delegator)
+    function getDelegate(address delegator)
         external
         view
-        returns (bytes32 trieRoot)
+        returns (
+            address delegatorAddress,
+            bytes32 trieRoot,
+            uint256 blockNumber
+        )
     {
         require(delegator != address(0), "delegator must be non-zero");
-        return delegation[delegator].trieRoot;
+        return (
+            delegator,
+            delegation[delegator].trieRoot,
+            delegation[delegator].blockNumber
+        );
     }
 
     function getDelegateBlockNumber(address delegator)

--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -14,7 +14,7 @@ struct DelegatorRecord {
 // https://docs.openzeppelin.com/contracts/4.x/api/security#Pausable
 // https://docs.openzeppelin.com/contracts/4.x/api/utils#MerkleProof
 contract MerkleDelegation is Ownable, Pausable {
-    address public governanceToken;
+    address public immutable governanceToken;
     mapping(address => DelegatorRecord) public delegation;
     mapping(address => address) public delegateToDelegator;
 

--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -10,11 +10,6 @@ struct DelegatorRecord {
     uint256 blockNumber;
 }
 
-struct DelegateeRecord {
-    address delegatee;
-    uint256 percentage; // 100,000 is 100%, 1,000 is 1%.
-}
-
 // https://docs.openzeppelin.com/contracts/4.x/api/access#Ownable
 // https://docs.openzeppelin.com/contracts/4.x/api/security#Pausable
 // https://docs.openzeppelin.com/contracts/4.x/api/utils#MerkleProof
@@ -23,44 +18,29 @@ contract MerkleDelegation is Ownable, Pausable {
     mapping(address => DelegatorRecord) public delegation;
     mapping(address => address) public delegateToDelegator;
 
-    event OwnerInitialized(address owner);
-    event OwnerChanged(address newOwner);
     event SetDelegates(
         address indexed delegator,
         bytes32 indexed trieRoot,
         uint256 blockNumber
     );
-    event ClearDelegate(address indexed delegator, bytes32 trieRoot);
 
     constructor(address _governanceToken) Ownable() Pausable() {
-        require(
-            _governanceToken != address(0),
-            "DR: token addr must be non-zero"
-        );
+        require(_governanceToken != address(0), "token addr must be non-zero");
         governanceToken = _governanceToken;
     }
 
-    //TODO: also the owner/admin can update the governance token address that is hashed with all leafs.
-    // function updateGovernanceToken(address newGovernanceToken) { governanceToken = newGovernancetoken; }
-
-    function setDelegateTrie(address delegator, bytes32 trieRoot)
-        external
-        whenNotPaused
-    {
-        require(delegator != address(0), "DR: delegator must be non-zero");
-        require(trieRoot != bytes32(0), "DR: trieRoot must be non-zero");
-        require(msg.sender == delegator, "DR: delegator must be msg.sender");
-        // Record to storage.
+    function setDelegateTrie(address delegator, bytes32 trieRoot) external whenNotPaused {
+        require(delegator == msg.sender, "delegator must be msg.sender");
+        require(trieRoot != bytes32(0), "trieRoot must be non-zero");
         delegation[delegator].trieRoot = trieRoot;
         delegation[delegator].blockNumber = block.number;
         emit SetDelegates(delegator, trieRoot, block.number);
     }
 
     function clearDelegateTrie(address delegator) external whenNotPaused {
-        require(delegator != address(0), "DR: delegator must be non-zero");
-        require(msg.sender == delegator, "DR: delegator must be msg.sender");
-        // Remove delegator record to save storage gas.
+        require(delegator == msg.sender, "delegator must be msg.sender");
         delete delegation[delegator];
+        emit SetDelegates(delegator, bytes32(0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421), block.number);
     }
 
     function pause() external onlyOwner whenNotPaused {
@@ -71,31 +51,17 @@ contract MerkleDelegation is Ownable, Pausable {
         _unpause();
     }
 
-    function getDelegateRoot(address delegator)
-        external
-        view
-        returns (bytes32 trieRoot)
-    {
-        require(delegator != address(0), "DR: delegator must be non-zero");
+    function getDelegateRoot(address delegator) external view returns (bytes32 trieRoot) {
+        require(delegator != address(0), "delegator must be non-zero");
         return delegation[delegator].trieRoot;
     }
 
-    function getDelegateBlockNumber(address delegator)
-        external
-        view
-        returns (uint256 blockNumber)
-    {
-        require(delegator != address(0), "DR: delegator must be non-zero");
-        return (delegation[delegator].blockNumber);
+    function getDelegateBlockNumber(address delegator) external view returns (uint256 blockNumber) {
+        require(delegator != address(0), "delegator must be non-zero");
+        return delegation[delegator].blockNumber;
     }
 
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override
-        onlyOwner
-        whenNotPaused
-    {
+    function transferOwnership(address newOwner) public virtual override onlyOwner whenNotPaused {
         _transferOwnership(newOwner);
     }
 }

--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -35,23 +35,16 @@ contract MerkleDelegation is Ownable, Pausable {
     {
         require(delegator == msg.sender, "delegator must be msg.sender");
         require(trieRoot != bytes32(0), "trieRoot must be non-zero");
-        delegation[delegator].trieRoot = trieRoot;
-        delegation[delegator].blockNumber = block.number;
-        emit SetDelegates(delegator, trieRoot, block.number);
+        _setDelegateTrie(delegator, trieRoot);
     }
 
     function clearDelegateTrie(address delegator) external whenNotPaused {
         require(delegator == msg.sender, "delegator must be msg.sender");
-        delegation[delegator].trieRoot = bytes32(
-            0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
-        );
-        delegation[delegator].blockNumber = block.number;
-        emit SetDelegates(
+        _setDelegateTrie(
             delegator,
             bytes32(
                 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
-            ),
-            block.number
+            )
         );
     }
 
@@ -96,5 +89,14 @@ contract MerkleDelegation is Ownable, Pausable {
         whenNotPaused
     {
         _transferOwnership(newOwner);
+    }
+
+    function _setDelegateTrie(address delegator, bytes32 trieRoot)
+        internal
+        whenNotPaused
+    {
+        delegation[delegator].trieRoot = trieRoot;
+        delegation[delegator].blockNumber = block.number;
+        emit SetDelegates(delegator, trieRoot, block.number);
     }
 }

--- a/contracts/MerkleDelegation.sol
+++ b/contracts/MerkleDelegation.sol
@@ -58,15 +58,10 @@ contract MerkleDelegation is Ownable, Pausable {
     function getDelegate(address delegator)
         external
         view
-        returns (
-            address delegatorAddress,
-            bytes32 trieRoot,
-            uint256 blockNumber
-        )
+        returns (bytes32 trieRoot, uint256 blockNumber)
     {
         require(delegator != address(0), "delegator must be non-zero");
         return (
-            delegator,
             delegation[delegator].trieRoot,
             delegation[delegator].blockNumber
         );

--- a/test/merkledelegation.test.ts
+++ b/test/merkledelegation.test.ts
@@ -137,11 +137,7 @@ describe('MerkleDelegation', () => {
             const blockNumber = BigNumber.from(await provider.getBlockNumber())
             expect(
                 JSON.stringify(await md.getDelegate(delegator.address))
-            ).equals(
-                `["${delegator.address}","${trieRoot}",${JSON.stringify(
-                    blockNumber
-                )}]`
-            )
+            ).equals(`["${trieRoot}",${JSON.stringify(blockNumber)}]`)
             expect(await md.getDelegateBlockNumber(delegator.address)).equals(
                 blockNumber
             )
@@ -159,11 +155,7 @@ describe('MerkleDelegation', () => {
             const blockNumber = BigNumber.from(await provider.getBlockNumber())
             expect(
                 JSON.stringify(await md.getDelegate(delegator.address))
-            ).equals(
-                `["${delegator.address}","${trieRoot}",${JSON.stringify(
-                    blockNumber
-                )}]`
-            )
+            ).equals(`["${trieRoot}",${JSON.stringify(blockNumber)}]`)
             expect(await md.getDelegateBlockNumber(delegator.address)).equals(
                 blockNumber
             )
@@ -182,11 +174,7 @@ describe('MerkleDelegation', () => {
             let blockNumber = BigNumber.from(await provider.getBlockNumber())
             expect(
                 JSON.stringify(await md.getDelegate(delegator.address))
-            ).equals(
-                `["${delegator.address}","${trieRoot}",${JSON.stringify(
-                    blockNumber
-                )}]`
-            )
+            ).equals(`["${trieRoot}",${JSON.stringify(blockNumber)}]`)
             expect(await md.getDelegateBlockNumber(delegator.address)).equals(
                 blockNumber
             )

--- a/test/merkledelegation.test.ts
+++ b/test/merkledelegation.test.ts
@@ -138,9 +138,6 @@ describe('MerkleDelegation', () => {
             expect(
                 JSON.stringify(await md.getDelegate(delegator.address))
             ).equals(`["${trieRoot}",${JSON.stringify(blockNumber)}]`)
-            expect(await md.getDelegateBlockNumber(delegator.address)).equals(
-                blockNumber
-            )
         })
     })
 
@@ -156,9 +153,6 @@ describe('MerkleDelegation', () => {
             expect(
                 JSON.stringify(await md.getDelegate(delegator.address))
             ).equals(`["${trieRoot}",${JSON.stringify(blockNumber)}]`)
-            expect(await md.getDelegateBlockNumber(delegator.address)).equals(
-                blockNumber
-            )
             await expect(
                 md.connect(delegator).clearDelegateTrie(constants.AddressZero)
             ).to.be.revertedWith('delegator must be msg.sender')
@@ -175,15 +169,16 @@ describe('MerkleDelegation', () => {
             expect(
                 JSON.stringify(await md.getDelegate(delegator.address))
             ).equals(`["${trieRoot}",${JSON.stringify(blockNumber)}]`)
-            expect(await md.getDelegateBlockNumber(delegator.address)).equals(
-                blockNumber
-            )
             const receipt = await successfulTransaction(
                 md.connect(delegator).clearDelegateTrie(delegator.address)
             )
             blockNumber = BigNumber.from(await provider.getBlockNumber())
-            expect(await md.getDelegateBlockNumber(delegator.address)).equals(
-                blockNumber
+            expect(
+                JSON.stringify(await md.getDelegate(delegator.address))
+            ).equals(
+                `["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",${JSON.stringify(
+                    blockNumber
+                )}]`
             )
             eventOf(md, 'SetDelegates').expectOne(receipt, {
                 delegator: delegator.address,

--- a/test/merkledelegation.test.ts
+++ b/test/merkledelegation.test.ts
@@ -135,7 +135,13 @@ describe('MerkleDelegation', () => {
                     .setDelegateTrie(delegator.address, trieRoot)
             )
             const blockNumber = BigNumber.from(await provider.getBlockNumber())
-            expect(await md.getDelegateRoot(delegator.address)).equals(trieRoot)
+            expect(
+                JSON.stringify(await md.getDelegate(delegator.address))
+            ).equals(
+                `["${delegator.address}","${trieRoot}",${JSON.stringify(
+                    blockNumber
+                )}]`
+            )
             expect(await md.getDelegateBlockNumber(delegator.address)).equals(
                 blockNumber
             )
@@ -151,7 +157,13 @@ describe('MerkleDelegation', () => {
                     .setDelegateTrie(delegator.address, trieRoot)
             )
             const blockNumber = BigNumber.from(await provider.getBlockNumber())
-            expect(await md.getDelegateRoot(delegator.address)).equals(trieRoot)
+            expect(
+                JSON.stringify(await md.getDelegate(delegator.address))
+            ).equals(
+                `["${delegator.address}","${trieRoot}",${JSON.stringify(
+                    blockNumber
+                )}]`
+            )
             expect(await md.getDelegateBlockNumber(delegator.address)).equals(
                 blockNumber
             )
@@ -168,7 +180,13 @@ describe('MerkleDelegation', () => {
                     .setDelegateTrie(delegator.address, trieRoot)
             )
             let blockNumber = BigNumber.from(await provider.getBlockNumber())
-            expect(await md.getDelegateRoot(delegator.address)).equals(trieRoot)
+            expect(
+                JSON.stringify(await md.getDelegate(delegator.address))
+            ).equals(
+                `["${delegator.address}","${trieRoot}",${JSON.stringify(
+                    blockNumber
+                )}]`
+            )
             expect(await md.getDelegateBlockNumber(delegator.address)).equals(
                 blockNumber
             )


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->

This cleans-up the contract and emits `SetDelegates` on any change to a `DelegatorRecord`